### PR TITLE
chore: use vanilla bluefin image as a base

### DIFF
--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -6,7 +6,7 @@ name: mac-blue
 description: MacBookPro11,4 that hopefully works
 
 # the base image to build on top of (FROM) and the version tag to use
-base-image: ghcr.io/ublue-os/bluefin-dx
+base-image: ghcr.io/ublue-os/bluefin
 image-version: 41 # latest is also supported if you want new updates ASAP
 
 # module configuration, executed in order
@@ -22,7 +22,19 @@ modules:
     # - https://copr.fedorainfracloud.org/coprs/atim/starship/repo/fedora-%OS_VERSION%/atim-starship-fedora-%OS_VERSION%.repo
     install:
       - mbpfan
+      - powertop
       - igt-gpu-tools
+      - cascadia-code-fonts
+      - google-droid-sans-mono-fonts
+      - mozilla-fira-mono-fonts
+      - docker-ce
+      - docker-ce-cli
+      - docker-buildx-plugin
+      - docker-compose-plugin
+      - containerd.io
+      - powerline-fonts
+      - code
+      - iotop
 
   # - type: default-flatpaks
   #   notify: true # Send notification after install/uninstall is finished (true/false)


### PR DESCRIPTION
We won't use many of the stuff that -dx comes with on that Mac, especially running VMs